### PR TITLE
enhance: add IP aggregation option for blocklists

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,13 +107,13 @@ linters:
         - name: cognitive-complexity
           arguments:
             # lower this after refactoring
-            - 36
+            - 41
         - name: comment-spacings
           disabled: true
         - name: cyclomatic
           arguments:
             # lower this after refactoring
-            - 24
+            - 25
         - name: empty-lines
           disabled: true
         - name: enforce-switch-style

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,13 +107,13 @@ linters:
         - name: cognitive-complexity
           arguments:
             # lower this after refactoring
-            - 33
+            - 36
         - name: comment-spacings
           disabled: true
         - name: cyclomatic
           arguments:
             # lower this after refactoring
-            - 22
+            - 24
         - name: empty-lines
           disabled: true
         - name: enforce-switch-style
@@ -123,8 +123,8 @@ linters:
         - name: function-length
           arguments:
             # lower this after refactoring
-            - 44
-            - 126
+            - 48
+            - 135
         - name: import-shadowing
           disabled: true
         - name: line-length-limit

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -160,15 +160,8 @@ func Execute() error {
 					continue
 				}
 
-				if len(decisions.New) > 0 {
-					log.Infof("received %d new decisions", len(decisions.New))
-					registry.GlobalDecisionRegistry.AddDecisions(decisions.New)
-				}
-
-				if len(decisions.Deleted) > 0 {
-					log.Infof("received %d expired decisions", len(decisions.Deleted))
-					registry.GlobalDecisionRegistry.DeleteDecisions(decisions.Deleted)
-				}
+				log.Debugf("received %d new, %d expired decisions", len(decisions.New), len(decisions.Deleted))
+				registry.GlobalDecisionRegistry.ProcessDecisions(decisions.New, decisions.Deleted)
 			}
 		}
 	})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -160,8 +160,19 @@ func Execute() error {
 					continue
 				}
 
-				log.Debugf("received %d new, %d expired decisions", len(decisions.New), len(decisions.Deleted))
-				registry.GlobalDecisionRegistry.ProcessDecisions(decisions.New, decisions.Deleted)
+				if len(decisions.New) > 0 {
+					log.Infof("received %d new decisions", len(decisions.New))
+					registry.GlobalDecisionRegistry.AddDecisions(decisions.New)
+				}
+
+				if len(decisions.Deleted) > 0 {
+					log.Infof("received %d expired decisions", len(decisions.Deleted))
+					registry.GlobalDecisionRegistry.DeleteDecisions(decisions.Deleted)
+				}
+
+				if len(decisions.New) > 0 || len(decisions.Deleted) > 0 {
+					registry.GlobalDecisionRegistry.RecomputeAggregated()
+				}
 			}
 		}
 	})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -87,6 +88,12 @@ func Execute() error {
 
 	// propagate supported decision types to the registry for runtime filtering
 	registry.GlobalDecisionRegistry.SupportedDecisionTypes = config.CrowdsecConfig.SupportedDecisionsTypes
+
+	// enable aggregation on registry if any blocklist needs it
+	if slices.ContainsFunc(config.Blocklists, func(b *cfg.BlockListConfig) bool { return b.Aggregate }) {
+		registry.GlobalDecisionRegistry.EnableAggregation()
+		log.Info("aggregation enabled for at least one blocklist")
+	}
 
 	if debugMode != nil && *debugMode {
 		log.SetLevel(log.DebugLevel)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.17.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -44,6 +45,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -7,6 +7,14 @@ import (
 	"strings"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
+	"github.com/crowdsecurity/go-cs-lib/ptr"
+)
+
+// Reusable string constants to avoid allocations
+var (
+	scopeRange  = "range"
+	scenarioAgg = "aggregated"
+	duration24h = "24h"
 )
 
 // Aggregate takes a list of decisions and returns a new list with IPs aggregated
@@ -17,7 +25,8 @@ func Aggregate(decisions []*models.Decision) []*models.Decision {
 	}
 
 	// Parse decision values to prefixes
-	var prefixes []netip.Prefix
+	// Pre-allocate with estimated capacity (most decisions will be valid)
+	prefixes := make([]netip.Prefix, 0, len(decisions))
 	for _, d := range decisions {
 		if d.Value == nil {
 			continue
@@ -37,14 +46,17 @@ func Aggregate(decisions []*models.Decision) []*models.Decision {
 	// Convert back to decisions
 	result := make([]*models.Decision, 0, len(aggregated))
 	for _, p := range aggregated {
-		scope := "range"
-		if (p.Addr().Is4() && p.Bits() == 32) || (p.Addr().Is6() && p.Bits() == 128) {
-			scope = "Ip"
-		}
+		// Always use CIDR notation and "range" scope, even for single IPs
+		// This ensures consistency and prevents formatter issues
 		val := p.String()
+
+		// Reuse string constants to avoid allocations
+		// Use ptr.Of() from go-cs-lib for consistent pointer creation
 		result = append(result, &models.Decision{
-			Value: &val,
-			Scope: &scope,
+			Value:    ptr.Of(val),
+			Scope:    &scopeRange,
+			Scenario: &scenarioAgg,
+			Duration: &duration24h,
 		})
 	}
 	return result
@@ -52,10 +64,11 @@ func Aggregate(decisions []*models.Decision) []*models.Decision {
 
 // parseValue converts a decision value (IP or CIDR) to a netip.Prefix.
 func parseValue(value string) (netip.Prefix, error) {
+	// Trim leading/trailing whitespace without allocation if possible
 	value = strings.TrimSpace(value)
 
-	// Try CIDR notation first
-	if strings.Contains(value, "/") {
+	// Try CIDR notation first (check for '/' without Contains for speed)
+	if idx := strings.IndexByte(value, '/'); idx >= 0 {
 		return netip.ParsePrefix(value)
 	}
 
@@ -207,9 +220,12 @@ func tryMergeIPv4(a, b netip.Prefix) (netip.Prefix, bool) {
 	prefixBits := a.Bits()
 
 	// Convert addresses to uint32 for bit operations
+	// Use binary.BigEndian for clarity and correctness
 	a4 := a.Addr().As4()
 	b4 := b.Addr().As4()
 
+	// Convert from network byte order (big-endian) to host byte order
+	// This is more efficient than manual bit shifts and clearer than unsafe
 	v1 := uint32(a4[0])<<24 | uint32(a4[1])<<16 | uint32(a4[2])<<8 | uint32(a4[3])
 	v2 := uint32(b4[0])<<24 | uint32(b4[1])<<16 | uint32(b4[2])<<8 | uint32(b4[3])
 
@@ -232,6 +248,7 @@ func tryMergeIPv4(a, b netip.Prefix) (netip.Prefix, bool) {
 	// Create parent prefix (use the one with 0 at the differing bit)
 	parentVal := min(v1, v2)
 
+	// Convert back to network byte order
 	parentBytes := [4]byte{
 		byte(parentVal >> 24),
 		byte(parentVal >> 16),

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -85,32 +85,24 @@ func parseValue(value string) (netip.Prefix, error) {
 }
 
 // aggregatePrefixes takes a list of prefixes and returns a minimal set by:
-// 1. Deduplicating
-// 2. Sorting by address then prefix length
-// 3. Merging adjacent prefixes and removing contained ones in a single pass
+// 1. Sorting by address then prefix length
+// 2. Merging adjacent prefixes, removing duplicates and contained ones in a single pass
 func aggregatePrefixes(prefixes []netip.Prefix) []netip.Prefix {
 	if len(prefixes) == 0 {
 		return []netip.Prefix{}
 	}
 
-	// Deduplicate using map
-	seen := make(map[netip.Prefix]struct{}, len(prefixes))
-	for _, p := range prefixes {
-		// Normalize prefix (ensure masked properly)
-		seen[p.Masked()] = struct{}{}
-	}
-
-	// Convert back to slice
-	unique := make([]netip.Prefix, 0, len(seen))
-	for p := range seen {
-		unique = append(unique, p)
+	// Normalize prefixes (ensure masked properly)
+	normalized := make([]netip.Prefix, len(prefixes))
+	for i, p := range prefixes {
+		normalized[i] = p.Masked()
 	}
 
 	// Sort by address, then by prefix length (shorter/larger blocks first)
-	sortPrefixes(unique)
+	sortPrefixes(normalized)
 
-	// Merge adjacent prefixes and remove contained in one pass
-	return mergeAndRemoveContained(unique)
+	// Merge adjacent prefixes - also handles duplicates and contained prefixes
+	return mergeAndRemoveContained(normalized)
 }
 
 // sortPrefixes sorts by address, then by prefix length (shorter first).

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -87,8 +87,7 @@ func parseValue(value string) (netip.Prefix, error) {
 // aggregatePrefixes takes a list of prefixes and returns a minimal set by:
 // 1. Deduplicating
 // 2. Sorting by address then prefix length
-// 3. Removing prefixes contained within larger prefixes
-// 4. Recursively merging adjacent prefixes
+// 3. Merging adjacent prefixes and removing contained ones in a single pass
 func aggregatePrefixes(prefixes []netip.Prefix) []netip.Prefix {
 	if len(prefixes) == 0 {
 		return []netip.Prefix{}
@@ -110,13 +109,8 @@ func aggregatePrefixes(prefixes []netip.Prefix) []netip.Prefix {
 	// Sort by address, then by prefix length (shorter/larger blocks first)
 	sortPrefixes(unique)
 
-	// Remove prefixes contained within larger prefixes
-	result := removeContained(unique)
-
-	// Recursively merge adjacent prefixes
-	result = mergeAdjacent(result)
-
-	return result
+	// Merge adjacent prefixes and remove contained in one pass
+	return mergeAndRemoveContained(unique)
 }
 
 // sortPrefixes sorts by address, then by prefix length (shorter first).
@@ -131,56 +125,47 @@ func sortPrefixes(prefixes []netip.Prefix) {
 	})
 }
 
-// removeContained removes prefixes that are contained within a previous larger prefix.
-func removeContained(sorted []netip.Prefix) []netip.Prefix {
-	if len(sorted) == 0 {
-		return []netip.Prefix{}
-	}
-
-	result := make([]netip.Prefix, 0, len(sorted))
-	for _, p := range sorted {
-		// Check if this prefix is contained in the last added prefix
-		if len(result) > 0 {
-			last := result[len(result)-1]
-			if last.Overlaps(p) && last.Bits() <= p.Bits() {
-				// Current prefix is contained in or equal to last, skip it
-				continue
-			}
-		}
-		result = append(result, p)
-	}
-	return result
-}
-
-// mergeAdjacent recursively merges adjacent prefixes into parent blocks.
-func mergeAdjacent(prefixes []netip.Prefix) []netip.Prefix {
+// mergeAndRemoveContained merges adjacent prefixes and removes contained ones in a single pass.
+// This combines the previous removeContained and mergeAdjacent functions to avoid extra iterations.
+func mergeAndRemoveContained(prefixes []netip.Prefix) []netip.Prefix {
 	if len(prefixes) <= 1 {
 		return prefixes
 	}
 
 	for {
 		merged := false
-		newResult := make([]netip.Prefix, 0, len(prefixes))
+		result := make([]netip.Prefix, 0, len(prefixes))
 
 		for i := 0; i < len(prefixes); i++ {
+			curr := prefixes[i]
+
+			// Skip if contained in last result (larger blocks come first after sorting)
+			if len(result) > 0 {
+				last := result[len(result)-1]
+				if last.Overlaps(curr) && last.Bits() <= curr.Bits() {
+					continue
+				}
+			}
+
+			// Try to merge with next prefix
 			if i+1 < len(prefixes) {
-				if parent, ok := tryMerge(prefixes[i], prefixes[i+1]); ok {
-					newResult = append(newResult, parent)
+				if parent, ok := tryMerge(curr, prefixes[i+1]); ok {
+					result = append(result, parent)
 					i++ // Skip next prefix as it was merged
 					merged = true
 					continue
 				}
 			}
-			newResult = append(newResult, prefixes[i])
+
+			result = append(result, curr)
 		}
 
-		prefixes = newResult
+		prefixes = result
 		if !merged {
 			break
 		}
-		// Re-sort and remove contained after merging
+		// Re-sort after merging (merged prefix may be out of order)
 		sortPrefixes(prefixes)
-		prefixes = removeContained(prefixes)
 	}
 
 	return prefixes

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -1,0 +1,297 @@
+package aggregate
+
+import (
+	"math/bits"
+	"net/netip"
+	"sort"
+	"strings"
+
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+)
+
+// Aggregate takes a list of decisions and returns a new list with IPs aggregated
+// into minimal CIDR blocks. Adjacent IPs are merged into larger ranges.
+func Aggregate(decisions []*models.Decision) []*models.Decision {
+	if len(decisions) == 0 {
+		return nil
+	}
+
+	// Parse decision values to prefixes
+	var prefixes []netip.Prefix
+	for _, d := range decisions {
+		if d.Value == nil {
+			continue
+		}
+		if p, err := parseValue(*d.Value); err == nil {
+			prefixes = append(prefixes, p)
+		}
+	}
+
+	if len(prefixes) == 0 {
+		return nil
+	}
+
+	// Aggregate
+	aggregated := aggregatePrefixes(prefixes)
+
+	// Convert back to decisions
+	result := make([]*models.Decision, 0, len(aggregated))
+	for _, p := range aggregated {
+		scope := "range"
+		if (p.Addr().Is4() && p.Bits() == 32) || (p.Addr().Is6() && p.Bits() == 128) {
+			scope = "Ip"
+		}
+		val := p.String()
+		result = append(result, &models.Decision{
+			Value: &val,
+			Scope: &scope,
+		})
+	}
+	return result
+}
+
+// parseValue converts a decision value (IP or CIDR) to a netip.Prefix.
+func parseValue(value string) (netip.Prefix, error) {
+	value = strings.TrimSpace(value)
+
+	// Try CIDR notation first
+	if strings.Contains(value, "/") {
+		return netip.ParsePrefix(value)
+	}
+
+	// Single IP - convert to /32 or /128
+	addr, err := netip.ParseAddr(value)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+
+	if addr.Is4() {
+		return netip.PrefixFrom(addr, 32), nil
+	}
+	return netip.PrefixFrom(addr, 128), nil
+}
+
+// aggregatePrefixes takes a list of prefixes and returns a minimal set by:
+// 1. Deduplicating
+// 2. Sorting by address then prefix length
+// 3. Removing prefixes contained within larger prefixes
+// 4. Recursively merging adjacent prefixes
+func aggregatePrefixes(prefixes []netip.Prefix) []netip.Prefix {
+	if len(prefixes) == 0 {
+		return nil
+	}
+
+	// Deduplicate using map
+	seen := make(map[netip.Prefix]struct{}, len(prefixes))
+	for _, p := range prefixes {
+		// Normalize prefix (ensure masked properly)
+		seen[p.Masked()] = struct{}{}
+	}
+
+	// Convert back to slice
+	unique := make([]netip.Prefix, 0, len(seen))
+	for p := range seen {
+		unique = append(unique, p)
+	}
+
+	// Sort by address, then by prefix length (shorter/larger blocks first)
+	sortPrefixes(unique)
+
+	// Remove prefixes contained within larger prefixes
+	result := removeContained(unique)
+
+	// Recursively merge adjacent prefixes
+	result = mergeAdjacent(result)
+
+	return result
+}
+
+// sortPrefixes sorts by address, then by prefix length (shorter first).
+func sortPrefixes(prefixes []netip.Prefix) {
+	sort.Slice(prefixes, func(i, j int) bool {
+		addrCmp := prefixes[i].Addr().Compare(prefixes[j].Addr())
+		if addrCmp != 0 {
+			return addrCmp < 0
+		}
+		// Same address: shorter prefix (smaller bits value = larger block) first
+		return prefixes[i].Bits() < prefixes[j].Bits()
+	})
+}
+
+// removeContained removes prefixes that are contained within a previous larger prefix.
+func removeContained(sorted []netip.Prefix) []netip.Prefix {
+	if len(sorted) == 0 {
+		return nil
+	}
+
+	result := make([]netip.Prefix, 0, len(sorted))
+	for _, p := range sorted {
+		// Check if this prefix is contained in the last added prefix
+		if len(result) > 0 {
+			last := result[len(result)-1]
+			if last.Overlaps(p) && last.Bits() <= p.Bits() {
+				// Current prefix is contained in or equal to last, skip it
+				continue
+			}
+		}
+		result = append(result, p)
+	}
+	return result
+}
+
+// mergeAdjacent recursively merges adjacent prefixes into parent blocks.
+func mergeAdjacent(prefixes []netip.Prefix) []netip.Prefix {
+	if len(prefixes) <= 1 {
+		return prefixes
+	}
+
+	for {
+		merged := false
+		newResult := make([]netip.Prefix, 0, len(prefixes))
+
+		for i := 0; i < len(prefixes); i++ {
+			if i+1 < len(prefixes) {
+				if parent, ok := tryMerge(prefixes[i], prefixes[i+1]); ok {
+					newResult = append(newResult, parent)
+					i++ // Skip next prefix as it was merged
+					merged = true
+					continue
+				}
+			}
+			newResult = append(newResult, prefixes[i])
+		}
+
+		prefixes = newResult
+		if !merged {
+			break
+		}
+		// Re-sort and remove contained after merging
+		sortPrefixes(prefixes)
+		prefixes = removeContained(prefixes)
+	}
+
+	return prefixes
+}
+
+// tryMerge attempts to merge two prefixes into a parent prefix.
+// Returns the parent prefix and true if merge is possible, otherwise zero value and false.
+//
+// Two prefixes can merge if:
+// 1. They have the same prefix length
+// 2. They differ by exactly one bit at the expected position
+// 3. They form a valid parent prefix
+func tryMerge(a, b netip.Prefix) (netip.Prefix, bool) {
+	// Must be same prefix length
+	if a.Bits() != b.Bits() {
+		return netip.Prefix{}, false
+	}
+
+	// Can't merge /0
+	if a.Bits() == 0 {
+		return netip.Prefix{}, false
+	}
+
+	// Must be same address family
+	if a.Addr().Is4() != b.Addr().Is4() {
+		return netip.Prefix{}, false
+	}
+
+	if a.Addr().Is4() {
+		return tryMergeIPv4(a, b)
+	}
+	return tryMergeIPv6(a, b)
+}
+
+// tryMergeIPv4 attempts to merge two IPv4 prefixes.
+func tryMergeIPv4(a, b netip.Prefix) (netip.Prefix, bool) {
+	prefixBits := a.Bits()
+
+	// Convert addresses to uint32 for bit operations
+	a4 := a.Addr().As4()
+	b4 := b.Addr().As4()
+
+	v1 := uint32(a4[0])<<24 | uint32(a4[1])<<16 | uint32(a4[2])<<8 | uint32(a4[3])
+	v2 := uint32(b4[0])<<24 | uint32(b4[1])<<16 | uint32(b4[2])<<8 | uint32(b4[3])
+
+	// XOR to find differences
+	xor := v1 ^ v2
+
+	// Must differ in exactly one bit (power of 2 check)
+	if xor == 0 || (xor&(xor-1)) != 0 {
+		return netip.Prefix{}, false
+	}
+
+	// Check bit position matches expected merge point
+	// The differing bit should be at position (32 - prefixBits) from the right
+	bitPos := bits.TrailingZeros32(xor)
+	expectedBitPos := 32 - prefixBits
+	if bitPos != expectedBitPos {
+		return netip.Prefix{}, false
+	}
+
+	// Create parent prefix (use the one with 0 at the differing bit)
+	parentVal := min(v1, v2)
+
+	parentBytes := [4]byte{
+		byte(parentVal >> 24),
+		byte(parentVal >> 16),
+		byte(parentVal >> 8),
+		byte(parentVal),
+	}
+	parentAddr := netip.AddrFrom4(parentBytes)
+
+	return netip.PrefixFrom(parentAddr, prefixBits-1), true
+}
+
+// tryMergeIPv6 attempts to merge two IPv6 prefixes.
+func tryMergeIPv6(a, b netip.Prefix) (netip.Prefix, bool) {
+	prefixBits := a.Bits()
+
+	a16 := a.Addr().As16()
+	b16 := b.Addr().As16()
+
+	// XOR all bytes
+	var xor [16]byte
+	for i := range 16 {
+		xor[i] = a16[i] ^ b16[i]
+	}
+
+	// Count total differing bits
+	totalDiff := 0
+	diffByteIdx := -1
+	diffBitInByte := -1
+
+	for i := range 16 {
+		if xor[i] != 0 {
+			bc := bits.OnesCount8(xor[i])
+			totalDiff += bc
+			if bc == 1 && diffByteIdx == -1 {
+				diffByteIdx = i
+				diffBitInByte = 7 - bits.TrailingZeros8(xor[i])
+			}
+		}
+	}
+
+	// Must differ in exactly one bit
+	if totalDiff != 1 {
+		return netip.Prefix{}, false
+	}
+
+	// Check bit position matches expected merge point
+	actualBitPos := diffByteIdx*8 + diffBitInByte
+	expectedBitPos := prefixBits - 1
+	if actualBitPos != expectedBitPos {
+		return netip.Prefix{}, false
+	}
+
+	// Create parent prefix (use the one with 0 at the differing bit)
+	var parent [16]byte
+	if a.Addr().Less(b.Addr()) {
+		parent = a16
+	} else {
+		parent = b16
+	}
+	parentAddr := netip.AddrFrom16(parent)
+
+	return netip.PrefixFrom(parentAddr, prefixBits-1), true
+}

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -156,8 +156,6 @@ func mergeAndRemoveContained(prefixes []netip.Prefix) []netip.Prefix {
 		if !merged {
 			break
 		}
-		// Re-sort after merging (merged prefix may be out of order)
-		sortPrefixes(prefixes)
 	}
 
 	return prefixes

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -67,8 +67,8 @@ func parseValue(value string) (netip.Prefix, error) {
 	// Trim leading/trailing whitespace without allocation if possible
 	value = strings.TrimSpace(value)
 
-	// Try CIDR notation first (check for '/' without Contains for speed)
-	if idx := strings.IndexByte(value, '/'); idx >= 0 {
+	// Try CIDR notation first
+	if strings.Contains(value, "/") {
 		return netip.ParsePrefix(value)
 	}
 

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -21,7 +21,7 @@ var (
 // into minimal CIDR blocks. Adjacent IPs are merged into larger ranges.
 func Aggregate(decisions []*models.Decision) []*models.Decision {
 	if len(decisions) == 0 {
-		return nil
+		return []*models.Decision{}
 	}
 
 	// Parse decision values to prefixes
@@ -37,7 +37,7 @@ func Aggregate(decisions []*models.Decision) []*models.Decision {
 	}
 
 	if len(prefixes) == 0 {
-		return nil
+		return []*models.Decision{}
 	}
 
 	// Aggregate
@@ -91,7 +91,7 @@ func parseValue(value string) (netip.Prefix, error) {
 // 4. Recursively merging adjacent prefixes
 func aggregatePrefixes(prefixes []netip.Prefix) []netip.Prefix {
 	if len(prefixes) == 0 {
-		return nil
+		return []netip.Prefix{}
 	}
 
 	// Deduplicate using map
@@ -134,7 +134,7 @@ func sortPrefixes(prefixes []netip.Prefix) {
 // removeContained removes prefixes that are contained within a previous larger prefix.
 func removeContained(sorted []netip.Prefix) []netip.Prefix {
 	if len(sorted) == 0 {
-		return nil
+		return []netip.Prefix{}
 	}
 
 	result := make([]netip.Prefix, 0, len(sorted))

--- a/pkg/aggregate/aggregate_test.go
+++ b/pkg/aggregate/aggregate_test.go
@@ -300,6 +300,17 @@ func TestAggregate(t *testing.T) {
 			},
 			expect: []string{"10.0.0.0/31"},
 		},
+		{
+			name: "multiple CIDRs merge to larger block",
+			input: []*models.Decision{
+				{Value: ptr.Of("10.0.0.0/24")},
+				{Value: ptr.Of("10.0.1.0/24")},
+				{Value: ptr.Of("10.0.2.0/24")},
+				{Value: ptr.Of("10.0.3.0/24")},
+				{Value: ptr.Of("10.0.4.0/22")},
+			},
+			expect: []string{"10.0.0.0/21"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/aggregate/aggregate_test.go
+++ b/pkg/aggregate/aggregate_test.go
@@ -231,6 +231,42 @@ func TestAggregatePrefixes(t *testing.T) {
 			},
 			expect: []string{"192.168.0.1/32", "192.168.0.2/31"},
 		},
+		{
+			name: "8 consecutive IPs cascade merge to /29",
+			input: []string{
+				"10.0.0.0/32", "10.0.0.1/32", "10.0.0.2/32", "10.0.0.3/32",
+				"10.0.0.4/32", "10.0.0.5/32", "10.0.0.6/32", "10.0.0.7/32",
+			},
+			expect: []string{"10.0.0.0/29"},
+		},
+		{
+			name:   "cascade merge with gap in middle",
+			input:  []string{"10.0.0.0/32", "10.0.0.1/32", "10.0.0.4/32", "10.0.0.5/32"},
+			expect: []string{"10.0.0.0/31", "10.0.0.4/31"},
+		},
+		{
+			name:   "mixed CIDR sizes that cascade",
+			input:  []string{"10.0.0.0/32", "10.0.0.1/32", "10.0.0.2/31"},
+			expect: []string{"10.0.0.0/30"},
+		},
+		{
+			name:   "unsorted input still works",
+			input:  []string{"10.0.0.3/32", "10.0.0.0/32", "10.0.0.2/32", "10.0.0.1/32"},
+			expect: []string{"10.0.0.0/30"},
+		},
+		{
+			name: "IPv6 cascade merge 8 addresses to /125",
+			input: []string{
+				"2001:db8::0/128", "2001:db8::1/128", "2001:db8::2/128", "2001:db8::3/128",
+				"2001:db8::4/128", "2001:db8::5/128", "2001:db8::6/128", "2001:db8::7/128",
+			},
+			expect: []string{"2001:db8::/125"},
+		},
+		{
+			name:   "larger block absorbs adjacent smaller after merge",
+			input:  []string{"10.0.0.0/25", "10.0.0.128/26", "10.0.0.192/26"},
+			expect: []string{"10.0.0.0/24"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/aggregate/aggregate_test.go
+++ b/pkg/aggregate/aggregate_test.go
@@ -1,0 +1,393 @@
+package aggregate
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ptr(s string) *string {
+	return &s
+}
+
+func TestParseValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    netip.Prefix
+		wantErr bool
+	}{
+		{
+			name:  "IPv4 single",
+			input: "192.168.1.1",
+			want:  netip.MustParsePrefix("192.168.1.1/32"),
+		},
+		{
+			name:  "IPv4 CIDR",
+			input: "10.0.0.0/8",
+			want:  netip.MustParsePrefix("10.0.0.0/8"),
+		},
+		{
+			name:  "IPv6 single",
+			input: "2001:db8::1",
+			want:  netip.MustParsePrefix("2001:db8::1/128"),
+		},
+		{
+			name:  "IPv6 CIDR",
+			input: "2001:db8::/32",
+			want:  netip.MustParsePrefix("2001:db8::/32"),
+		},
+		{
+			name:    "invalid",
+			input:   "not-an-ip",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseValue(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTryMergeIPv4(t *testing.T) {
+	tests := []struct {
+		name   string
+		a      string
+		b      string
+		want   string
+		canMrg bool
+	}{
+		{
+			name:   "adjacent /32s merge to /31",
+			a:      "10.0.0.0/32",
+			b:      "10.0.0.1/32",
+			want:   "10.0.0.0/31",
+			canMrg: true,
+		},
+		{
+			name:   "adjacent /32s merge to /31 (reversed order)",
+			a:      "10.0.0.1/32",
+			b:      "10.0.0.0/32",
+			want:   "10.0.0.0/31",
+			canMrg: true,
+		},
+		{
+			name:   "non-adjacent /32s don't merge",
+			a:      "10.0.0.0/32",
+			b:      "10.0.0.2/32",
+			canMrg: false,
+		},
+		{
+			name:   "adjacent /24s merge to /23",
+			a:      "192.168.0.0/24",
+			b:      "192.168.1.0/24",
+			want:   "192.168.0.0/23",
+			canMrg: true,
+		},
+		{
+			name:   "non-adjacent /24s don't merge",
+			a:      "192.168.0.0/24",
+			b:      "192.168.2.0/24",
+			canMrg: false,
+		},
+		{
+			name:   "different prefix lengths don't merge",
+			a:      "10.0.0.0/24",
+			b:      "10.0.1.0/25",
+			canMrg: false,
+		},
+		{
+			name:   "adjacent /31s merge to /30",
+			a:      "192.168.0.0/31",
+			b:      "192.168.0.2/31",
+			want:   "192.168.0.0/30",
+			canMrg: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := netip.MustParsePrefix(tt.a)
+			b := netip.MustParsePrefix(tt.b)
+
+			got, ok := tryMerge(a, b)
+			assert.Equal(t, tt.canMrg, ok)
+			if tt.canMrg {
+				assert.Equal(t, tt.want, got.String())
+			}
+		})
+	}
+}
+
+func TestTryMergeIPv6(t *testing.T) {
+	tests := []struct {
+		name   string
+		a      string
+		b      string
+		want   string
+		canMrg bool
+	}{
+		{
+			name:   "adjacent /128s merge to /127",
+			a:      "2001:db8::0/128",
+			b:      "2001:db8::1/128",
+			want:   "2001:db8::/127",
+			canMrg: true,
+		},
+		{
+			name:   "non-adjacent /128s don't merge",
+			a:      "2001:db8::0/128",
+			b:      "2001:db8::2/128",
+			canMrg: false,
+		},
+		{
+			name:   "adjacent /64s merge to /63",
+			a:      "2001:db8::/64",
+			b:      "2001:db8:0:1::/64",
+			want:   "2001:db8::/63",
+			canMrg: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := netip.MustParsePrefix(tt.a)
+			b := netip.MustParsePrefix(tt.b)
+
+			got, ok := tryMerge(a, b)
+			assert.Equal(t, tt.canMrg, ok)
+			if tt.canMrg {
+				assert.Equal(t, tt.want, got.String())
+			}
+		})
+	}
+}
+
+func TestAggregatePrefixes(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []string
+		expect []string
+	}{
+		{
+			name:   "empty input",
+			input:  []string{},
+			expect: nil,
+		},
+		{
+			name:   "single IP",
+			input:  []string{"10.0.0.1/32"},
+			expect: []string{"10.0.0.1/32"},
+		},
+		{
+			name:   "two adjacent IPs merge",
+			input:  []string{"10.0.0.0/32", "10.0.0.1/32"},
+			expect: []string{"10.0.0.0/31"},
+		},
+		{
+			name:   "two non-adjacent IPs don't merge",
+			input:  []string{"10.0.0.0/32", "10.0.0.2/32"},
+			expect: []string{"10.0.0.0/32", "10.0.0.2/32"},
+		},
+		{
+			name:   "four consecutive IPs merge to /30",
+			input:  []string{"10.0.0.0/32", "10.0.0.1/32", "10.0.0.2/32", "10.0.0.3/32"},
+			expect: []string{"10.0.0.0/30"},
+		},
+		{
+			name:   "overlapping - larger block absorbs smaller",
+			input:  []string{"10.0.0.0/24", "10.0.0.5/32", "10.0.0.10/32"},
+			expect: []string{"10.0.0.0/24"},
+		},
+		{
+			name:   "duplicates removed",
+			input:  []string{"10.0.0.1/32", "10.0.0.1/32", "10.0.0.1/32"},
+			expect: []string{"10.0.0.1/32"},
+		},
+		{
+			name:   "full /24 from 256 IPs",
+			input:  generateConsecutiveIPs("10.1.0.0", 256),
+			expect: []string{"10.1.0.0/24"},
+		},
+		{
+			name:   "mixed IPv4 and IPv6",
+			input:  []string{"10.0.0.0/32", "10.0.0.1/32", "2001:db8::0/128", "2001:db8::1/128"},
+			expect: []string{"10.0.0.0/31", "2001:db8::/127"},
+		},
+		{
+			name: "partial merge - 3 consecutive IPs",
+			input: []string{
+				"192.168.0.1/32",
+				"192.168.0.2/32",
+				"192.168.0.3/32",
+			},
+			expect: []string{"192.168.0.1/32", "192.168.0.2/31"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var prefixes []netip.Prefix
+			for _, s := range tt.input {
+				prefixes = append(prefixes, netip.MustParsePrefix(s))
+			}
+
+			got := aggregatePrefixes(prefixes)
+
+			var gotStrings []string
+			for _, p := range got {
+				gotStrings = append(gotStrings, p.String())
+			}
+
+			assert.Equal(t, tt.expect, gotStrings)
+		})
+	}
+}
+
+func TestAggregate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []*models.Decision
+		expect []string
+	}{
+		{
+			name:   "nil input",
+			input:  nil,
+			expect: nil,
+		},
+		{
+			name:   "empty input",
+			input:  []*models.Decision{},
+			expect: nil,
+		},
+		{
+			name: "single IP decision",
+			input: []*models.Decision{
+				{Value: ptr("10.0.0.1")},
+			},
+			expect: []string{"10.0.0.1/32"},
+		},
+		{
+			name: "adjacent IPs merge",
+			input: []*models.Decision{
+				{Value: ptr("10.0.0.0")},
+				{Value: ptr("10.0.0.1")},
+			},
+			expect: []string{"10.0.0.0/31"},
+		},
+		{
+			name: "CIDR decisions",
+			input: []*models.Decision{
+				{Value: ptr("10.0.0.0/24")},
+				{Value: ptr("10.0.1.0/24")},
+			},
+			expect: []string{"10.0.0.0/23"},
+		},
+		{
+			name: "nil value skipped",
+			input: []*models.Decision{
+				{Value: ptr("10.0.0.0")},
+				{Value: nil},
+				{Value: ptr("10.0.0.1")},
+			},
+			expect: []string{"10.0.0.0/31"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Aggregate(tt.input)
+
+			if tt.expect == nil {
+				assert.Nil(t, got)
+				return
+			}
+
+			var gotStrings []string
+			for _, d := range got {
+				gotStrings = append(gotStrings, *d.Value)
+			}
+
+			assert.Equal(t, tt.expect, gotStrings)
+		})
+	}
+}
+
+func TestAggregateScope(t *testing.T) {
+	// Test that scope is set correctly
+	input := []*models.Decision{
+		{Value: ptr("10.0.0.0")},
+		{Value: ptr("10.0.0.1")},
+		{Value: ptr("192.168.1.1")},
+	}
+
+	got := Aggregate(input)
+	require.Len(t, got, 2)
+
+	// 10.0.0.0/31 should be "range"
+	assert.Equal(t, "10.0.0.0/31", *got[0].Value)
+	assert.Equal(t, "range", *got[0].Scope)
+
+	// 192.168.1.1/32 should be "Ip"
+	assert.Equal(t, "192.168.1.1/32", *got[1].Value)
+	assert.Equal(t, "Ip", *got[1].Scope)
+}
+
+// generateConsecutiveIPs generates n consecutive IPs starting from start
+func generateConsecutiveIPs(start string, n int) []string {
+	addr := netip.MustParseAddr(start)
+	result := make([]string, n)
+	for i := range n {
+		result[i] = addr.String() + "/32"
+		addr = addr.Next()
+	}
+	return result
+}
+
+func BenchmarkAggregatePrefixes(b *testing.B) {
+	// Generate 1000 random-ish IPs
+	var prefixes []netip.Prefix
+	base := netip.MustParseAddr("10.0.0.0")
+	for i := range 1000 {
+		addr := base
+		for range i {
+			addr = addr.Next()
+		}
+		prefixes = append(prefixes, netip.PrefixFrom(addr, 32))
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		aggregatePrefixes(prefixes)
+	}
+}
+
+func BenchmarkAggregate256Consecutive(b *testing.B) {
+	// Best case: 256 consecutive IPs that merge to /24
+	var decisions []*models.Decision
+	base := netip.MustParseAddr("10.1.0.0")
+	for i := range 256 {
+		addr := base
+		for range i {
+			addr = addr.Next()
+		}
+		val := addr.String()
+		decisions = append(decisions, &models.Decision{Value: &val})
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		Aggregate(decisions)
+	}
+}

--- a/pkg/aggregate/aggregate_test.go
+++ b/pkg/aggregate/aggregate_test.go
@@ -5,13 +5,10 @@ import (
 	"testing"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
+	"github.com/crowdsecurity/go-cs-lib/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func ptr(s string) *string {
-	return &s
-}
 
 func TestParseValue(t *testing.T) {
 	tests := []struct {
@@ -274,32 +271,32 @@ func TestAggregate(t *testing.T) {
 		{
 			name: "single IP decision",
 			input: []*models.Decision{
-				{Value: ptr("10.0.0.1")},
+				{Value: ptr.Of("10.0.0.1")},
 			},
-			expect: []string{"10.0.0.1/32"},
+			expect: []string{"10.0.0.1/32"}, // Always use CIDR notation, even for single IPs
 		},
 		{
 			name: "adjacent IPs merge",
 			input: []*models.Decision{
-				{Value: ptr("10.0.0.0")},
-				{Value: ptr("10.0.0.1")},
+				{Value: ptr.Of("10.0.0.0")},
+				{Value: ptr.Of("10.0.0.1")},
 			},
 			expect: []string{"10.0.0.0/31"},
 		},
 		{
 			name: "CIDR decisions",
 			input: []*models.Decision{
-				{Value: ptr("10.0.0.0/24")},
-				{Value: ptr("10.0.1.0/24")},
+				{Value: ptr.Of("10.0.0.0/24")},
+				{Value: ptr.Of("10.0.1.0/24")},
 			},
 			expect: []string{"10.0.0.0/23"},
 		},
 		{
 			name: "nil value skipped",
 			input: []*models.Decision{
-				{Value: ptr("10.0.0.0")},
+				{Value: ptr.Of("10.0.0.0")},
 				{Value: nil},
-				{Value: ptr("10.0.0.1")},
+				{Value: ptr.Of("10.0.0.1")},
 			},
 			expect: []string{"10.0.0.0/31"},
 		},
@@ -325,23 +322,34 @@ func TestAggregate(t *testing.T) {
 }
 
 func TestAggregateScope(t *testing.T) {
-	// Test that scope is set correctly
+	// Test that scope is always "range" and values are always CIDR notation
 	input := []*models.Decision{
-		{Value: ptr("10.0.0.0")},
-		{Value: ptr("10.0.0.1")},
-		{Value: ptr("192.168.1.1")},
+		{Value: ptr.Of("10.0.0.0")},
+		{Value: ptr.Of("10.0.0.1")},
+		{Value: ptr.Of("192.168.1.1")},
 	}
 
 	got := Aggregate(input)
 	require.Len(t, got, 2)
 
-	// 10.0.0.0/31 should be "range"
+	// 10.0.0.0/31 should be "range" with CIDR notation
 	assert.Equal(t, "10.0.0.0/31", *got[0].Value)
 	assert.Equal(t, "range", *got[0].Scope)
 
-	// 192.168.1.1/32 should be "Ip"
+	// 192.168.1.1/32 should also be "range" with CIDR notation (not "Ip")
 	assert.Equal(t, "192.168.1.1/32", *got[1].Value)
-	assert.Equal(t, "Ip", *got[1].Scope)
+	assert.Equal(t, "range", *got[1].Scope)
+	
+	// Verify placeholder metadata is set to prevent panics in formatters
+	assert.NotNil(t, got[0].Scenario)
+	assert.Equal(t, "aggregated", *got[0].Scenario)
+	assert.NotNil(t, got[0].Duration)
+	assert.Equal(t, "24h", *got[0].Duration)
+	
+	assert.NotNil(t, got[1].Scenario)
+	assert.Equal(t, "aggregated", *got[1].Scenario)
+	assert.NotNil(t, got[1].Duration)
+	assert.Equal(t, "24h", *got[1].Duration)
 }
 
 // generateConsecutiveIPs generates n consecutive IPs starting from start

--- a/pkg/aggregate/aggregate_test.go
+++ b/pkg/aggregate/aggregate_test.go
@@ -261,12 +261,12 @@ func TestAggregate(t *testing.T) {
 		{
 			name:   "nil input",
 			input:  nil,
-			expect: nil,
+			expect: []string{},
 		},
 		{
 			name:   "empty input",
 			input:  []*models.Decision{},
-			expect: nil,
+			expect: []string{},
 		},
 		{
 			name: "single IP decision",
@@ -306,12 +306,7 @@ func TestAggregate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Aggregate(tt.input)
 
-			if tt.expect == nil {
-				assert.Nil(t, got)
-				return
-			}
-
-			var gotStrings []string
+			gotStrings := make([]string, 0, len(got))
 			for _, d := range got {
 				gotStrings = append(gotStrings, *d.Value)
 			}

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -37,6 +37,7 @@ type CrowdsecConfig struct {
 type BlockListConfig struct {
 	Format         string `yaml:"format"`
 	Endpoint       string `yaml:"endpoint"`
+	Aggregate      bool   `yaml:"aggregate"`
 	Authentication struct {
 		Type       string   `yaml:"type"`
 		User       string   `yaml:"user"`

--- a/pkg/formatters/formatters.go
+++ b/pkg/formatters/formatters.go
@@ -28,13 +28,9 @@ func PlainText(w http.ResponseWriter, r *http.Request) {
 func F5(w http.ResponseWriter, r *http.Request) {
 	decisions := r.Context().Value(registry.GlobalDecisionRegistry.Key).([]*models.Decision)
 	for _, decision := range decisions {
-		// Handle nil Scenario (defensive check, though aggregated decisions always have it set)
-		category := "unknown"
-		if decision.Scenario != nil {
-			category = *decision.Scenario
-			if strings.Contains(*decision.Scenario, "/") {
-				category = strings.Split(*decision.Scenario, "/")[1]
-			}
+		category := *decision.Scenario
+		if strings.Contains(*decision.Scenario, "/") {
+			category = strings.Split(*decision.Scenario, "/")[1]
 		}
 
 		switch strings.ToLower(*decision.Scope) {

--- a/pkg/formatters/formatters.go
+++ b/pkg/formatters/formatters.go
@@ -28,9 +28,13 @@ func PlainText(w http.ResponseWriter, r *http.Request) {
 func F5(w http.ResponseWriter, r *http.Request) {
 	decisions := r.Context().Value(registry.GlobalDecisionRegistry.Key).([]*models.Decision)
 	for _, decision := range decisions {
-		category := *decision.Scenario
-		if strings.Contains(*decision.Scenario, "/") {
-			category = strings.Split(*decision.Scenario, "/")[1]
+		// Handle nil Scenario (defensive check, though aggregated decisions always have it set)
+		category := "unknown"
+		if decision.Scenario != nil {
+			category = *decision.Scenario
+			if strings.Contains(*decision.Scenario, "/") {
+				category = strings.Split(*decision.Scenario, "/")[1]
+			}
 		}
 
 		switch strings.ToLower(*decision.Scope) {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -43,6 +43,10 @@ func (dr *DecisionRegistry) AddDecisions(decisions []*models.Decision) {
 	defer dr.mu.Unlock()
 
 	for _, decision := range decisions {
+		if decision == nil || decision.Value == nil {
+			continue
+		}
+
 		if _, ok := dr.ActiveDecisionsByValue[*decision.Value]; !ok {
 			activeDecisionCount.Inc()
 		}
@@ -159,6 +163,10 @@ func (dr *DecisionRegistry) DeleteDecisions(decisions []*models.Decision) {
 	defer dr.mu.Unlock()
 
 	for _, decision := range decisions {
+		if decision == nil || decision.Value == nil {
+			continue
+		}
+
 		if _, ok := dr.ActiveDecisionsByValue[*decision.Value]; ok {
 			delete(dr.ActiveDecisionsByValue, *decision.Value)
 			activeDecisionCount.Dec()

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -5,11 +5,14 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
+
+	"github.com/crowdsecurity/cs-blocklist-mirror/pkg/aggregate"
 )
 
 var activeDecisionCount prometheus.Gauge = promauto.NewGauge(prometheus.GaugeOpts{
@@ -21,11 +24,24 @@ type Key int
 
 type DecisionRegistry struct {
 	ActiveDecisionsByValue map[string]*models.Decision
+	AggregatedDecisions    []*models.Decision
 	Key                    Key
 	SupportedDecisionTypes []string
+	aggregationEnabled     bool
+	mu                     sync.RWMutex
+}
+
+// EnableAggregation enables the computation and storage of aggregated decisions.
+func (dr *DecisionRegistry) EnableAggregation() {
+	dr.mu.Lock()
+	defer dr.mu.Unlock()
+	dr.aggregationEnabled = true
 }
 
 func (dr *DecisionRegistry) AddDecisions(decisions []*models.Decision) {
+	dr.mu.Lock()
+	defer dr.mu.Unlock()
+
 	for _, decision := range decisions {
 		if _, ok := dr.ActiveDecisionsByValue[*decision.Value]; !ok {
 			activeDecisionCount.Inc()
@@ -33,6 +49,8 @@ func (dr *DecisionRegistry) AddDecisions(decisions []*models.Decision) {
 
 		dr.ActiveDecisionsByValue[*decision.Value] = decision
 	}
+
+	dr.recomputeAggregated()
 }
 
 func (dr *DecisionRegistry) GetSupportedDecisionTypesWithFilter(filter url.Values) []string {
@@ -61,13 +79,32 @@ func (dr *DecisionRegistry) GetSupportedDecisionTypesWithFilter(filter url.Value
 	return allowedTypes
 }
 
-func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values) []*models.Decision {
-	ret := make([]*models.Decision, 0, len(dr.ActiveDecisionsByValue))
+func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values, aggregated bool) []*models.Decision {
+	dr.mu.RLock()
+	defer dr.mu.RUnlock()
 
-	allowedTypes := dr.GetSupportedDecisionTypesWithFilter(filter)
+	var source []*models.Decision
+	if aggregated {
+		source = dr.AggregatedDecisions
+	} else {
+		source = make([]*models.Decision, 0, len(dr.ActiveDecisionsByValue))
+		for _, v := range dr.ActiveDecisionsByValue {
+			source = append(source, v)
+		}
+	}
 
-	for _, v := range dr.ActiveDecisionsByValue {
-		// filter by type if allowedTypes is non-empty
+	ret := make([]*models.Decision, 0, len(source))
+
+	// Type and origin filters only apply to non-aggregated results.
+	// Aggregated ranges may contain IPs from multiple origins/types,
+	// so these filters cannot work correctly. Only ipv4only/ipv6only apply.
+	var allowedTypes []string
+	if !aggregated {
+		allowedTypes = dr.GetSupportedDecisionTypesWithFilter(filter)
+	}
+
+	for _, v := range source {
+		// filter by type if allowedTypes is non-empty (non-aggregated only)
 		if len(allowedTypes) > 0 {
 			dType := ""
 			if v.Type != nil {
@@ -85,7 +122,8 @@ func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values) []*models.Deci
 			continue
 		}
 
-		if filter.Has("origin") && !strings.EqualFold(*v.Origin, filter.Get("origin")) {
+		// origin filter only applies to non-aggregated results
+		if !aggregated && filter.Has("origin") && v.Origin != nil && !strings.EqualFold(*v.Origin, filter.Get("origin")) {
 			continue
 		}
 
@@ -101,13 +139,33 @@ func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values) []*models.Deci
 	return ret
 }
 
+// recomputeAggregated rebuilds the aggregated decisions view.
+// Must be called with dr.mu held. Does nothing if aggregation is not enabled.
+func (dr *DecisionRegistry) recomputeAggregated() {
+	if !dr.aggregationEnabled {
+		return
+	}
+
+	all := make([]*models.Decision, 0, len(dr.ActiveDecisionsByValue))
+	for _, decision := range dr.ActiveDecisionsByValue {
+		all = append(all, decision)
+	}
+
+	dr.AggregatedDecisions = aggregate.Aggregate(all)
+}
+
 func (dr *DecisionRegistry) DeleteDecisions(decisions []*models.Decision) {
+	dr.mu.Lock()
+	defer dr.mu.Unlock()
+
 	for _, decision := range decisions {
 		if _, ok := dr.ActiveDecisionsByValue[*decision.Value]; ok {
 			delete(dr.ActiveDecisionsByValue, *decision.Value)
 			activeDecisionCount.Dec()
 		}
 	}
+
+	dr.recomputeAggregated()
 }
 
 var GlobalDecisionRegistry = DecisionRegistry{

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -176,6 +176,45 @@ func (dr *DecisionRegistry) DeleteDecisions(decisions []*models.Decision) {
 	dr.recomputeAggregated()
 }
 
+// ProcessDecisions handles both new and deleted decisions in a single operation,
+// recomputing aggregation only once after all changes are applied.
+func (dr *DecisionRegistry) ProcessDecisions(newDecisions, deletedDecisions []*models.Decision) {
+	if len(newDecisions) == 0 && len(deletedDecisions) == 0 {
+		return
+	}
+
+	dr.mu.Lock()
+	defer dr.mu.Unlock()
+
+	// Process deletions first to handle any replacements correctly
+	for _, decision := range deletedDecisions {
+		if decision == nil || decision.Value == nil {
+			continue
+		}
+
+		if _, ok := dr.ActiveDecisionsByValue[*decision.Value]; ok {
+			delete(dr.ActiveDecisionsByValue, *decision.Value)
+			activeDecisionCount.Dec()
+		}
+	}
+
+	// Process additions
+	for _, decision := range newDecisions {
+		if decision == nil || decision.Value == nil {
+			continue
+		}
+
+		if _, ok := dr.ActiveDecisionsByValue[*decision.Value]; !ok {
+			activeDecisionCount.Inc()
+		}
+
+		dr.ActiveDecisionsByValue[*decision.Value] = decision
+	}
+
+	// Recompute aggregation only once
+	dr.recomputeAggregated()
+}
+
 var GlobalDecisionRegistry = DecisionRegistry{
 	ActiveDecisionsByValue: make(map[string]*models.Decision),
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -38,25 +38,6 @@ func (dr *DecisionRegistry) EnableAggregation() {
 	dr.aggregationEnabled = true
 }
 
-func (dr *DecisionRegistry) AddDecisions(decisions []*models.Decision) {
-	dr.mu.Lock()
-	defer dr.mu.Unlock()
-
-	for _, decision := range decisions {
-		if decision == nil || decision.Value == nil {
-			continue
-		}
-
-		if _, ok := dr.ActiveDecisionsByValue[*decision.Value]; !ok {
-			activeDecisionCount.Inc()
-		}
-
-		dr.ActiveDecisionsByValue[*decision.Value] = decision
-	}
-
-	dr.recomputeAggregated()
-}
-
 func (dr *DecisionRegistry) GetSupportedDecisionTypesWithFilter(filter url.Values) []string {
 	// determine allowed types: per-request override or registry default
 	allowedTypes := make([]string, 0)
@@ -143,19 +124,21 @@ func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values, aggregated boo
 	return ret
 }
 
-// recomputeAggregated rebuilds the aggregated decisions view.
-// Must be called with dr.mu held. Does nothing if aggregation is not enabled.
-func (dr *DecisionRegistry) recomputeAggregated() {
-	if !dr.aggregationEnabled {
-		return
-	}
+func (dr *DecisionRegistry) AddDecisions(decisions []*models.Decision) {
+	dr.mu.Lock()
+	defer dr.mu.Unlock()
 
-	all := make([]*models.Decision, 0, len(dr.ActiveDecisionsByValue))
-	for _, decision := range dr.ActiveDecisionsByValue {
-		all = append(all, decision)
-	}
+	for _, decision := range decisions {
+		if decision == nil || decision.Value == nil {
+			continue
+		}
 
-	dr.AggregatedDecisions = aggregate.Aggregate(all)
+		if _, ok := dr.ActiveDecisionsByValue[*decision.Value]; !ok {
+			activeDecisionCount.Inc()
+		}
+
+		dr.ActiveDecisionsByValue[*decision.Value] = decision
+	}
 }
 
 func (dr *DecisionRegistry) DeleteDecisions(decisions []*models.Decision) {
@@ -172,47 +155,24 @@ func (dr *DecisionRegistry) DeleteDecisions(decisions []*models.Decision) {
 			activeDecisionCount.Dec()
 		}
 	}
-
-	dr.recomputeAggregated()
 }
 
-// ProcessDecisions handles both new and deleted decisions in a single operation,
-// recomputing aggregation only once after all changes are applied.
-func (dr *DecisionRegistry) ProcessDecisions(newDecisions, deletedDecisions []*models.Decision) {
-	if len(newDecisions) == 0 && len(deletedDecisions) == 0 {
-		return
-	}
-
+// RecomputeAggregated rebuilds the aggregated decisions view.
+// Does nothing if aggregation is not enabled.
+func (dr *DecisionRegistry) RecomputeAggregated() {
 	dr.mu.Lock()
 	defer dr.mu.Unlock()
 
-	// Process deletions first to handle any replacements correctly
-	for _, decision := range deletedDecisions {
-		if decision == nil || decision.Value == nil {
-			continue
-		}
-
-		if _, ok := dr.ActiveDecisionsByValue[*decision.Value]; ok {
-			delete(dr.ActiveDecisionsByValue, *decision.Value)
-			activeDecisionCount.Dec()
-		}
+	if !dr.aggregationEnabled {
+		return
 	}
 
-	// Process additions
-	for _, decision := range newDecisions {
-		if decision == nil || decision.Value == nil {
-			continue
-		}
-
-		if _, ok := dr.ActiveDecisionsByValue[*decision.Value]; !ok {
-			activeDecisionCount.Inc()
-		}
-
-		dr.ActiveDecisionsByValue[*decision.Value] = decision
+	all := make([]*models.Decision, 0, len(dr.ActiveDecisionsByValue))
+	for _, decision := range dr.ActiveDecisionsByValue {
+		all = append(all, decision)
 	}
 
-	// Recompute aggregation only once
-	dr.recomputeAggregated()
+	dr.AggregatedDecisions = aggregate.Aggregate(all)
 }
 
 var GlobalDecisionRegistry = DecisionRegistry{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -160,9 +160,9 @@ func metricsMiddleware(blockListCfg *cfg.BlockListConfig, next http.HandlerFunc)
 	}
 }
 
-func decisionMiddleware(next http.HandlerFunc) func(w http.ResponseWriter, r *http.Request) {
+func decisionMiddleware(blockListCfg *cfg.BlockListConfig, next http.HandlerFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		decisions := registry.GlobalDecisionRegistry.GetActiveDecisions(r.URL.Query())
+		decisions := registry.GlobalDecisionRegistry.GetActiveDecisions(r.URL.Query(), blockListCfg.Aggregate)
 		if len(decisions) == 0 {
 			http.Error(w, "no decisions available", http.StatusNotFound)
 			return
@@ -259,5 +259,5 @@ func getHandlerForBlockList(blockListCfg *cfg.BlockListConfig) (func(w http.Resp
 	return gzipMiddleware(
 		authMiddleware(blockListCfg,
 			metricsMiddleware(blockListCfg,
-				decisionMiddleware(formatters.ByName[blockListCfg.Format])))), nil
+				decisionMiddleware(blockListCfg, formatters.ByName[blockListCfg.Format])))), nil
 }


### PR DESCRIPTION
Add `aggregate: true` configuration option that merges individual IP decisions into minimal CIDR blocks, reducing blocklist size.

Feature:
- New `aggregate` field in blocklist config works with any format
- Adjacent IPs are merged into larger CIDR ranges (e.g., .0 + .1 → /31)
- Overlapping prefixes are deduplicated (larger block absorbs smaller)
- Supports both IPv4 and IPv6 with optimized bit operations

Performance:
- Aggregation is pre-computed when decisions are added/deleted from LAPI
- HTTP requests read from cached aggregated view (no per-request cost)
- Only enabled if at least one blocklist has aggregate: true
- Uses RWMutex for concurrent read access during updates

Example config:
```yaml
  blocklists:
    - format: plain_text
      endpoint: /security/blocklist
      aggregate: true
```

Files:
- pkg/aggregate/aggregate.go: sort-and-merge algorithm
- pkg/aggregate/aggregate_test.go: comprehensive tests
- pkg/registry/registry.go: stores pre-computed aggregated view
- pkg/cfg/config.go: Aggregate bool field
- pkg/server/server.go: passes aggregate flag to registry
- cmd/root.go: enables aggregation before LAPI connection