### PR TITLE
enhance: add pagination support for blocklists

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -11,6 +12,15 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 )
+
+// PaginatedResult holds paginated decisions with metadata
+type PaginatedResult struct {
+	Decisions  []*models.Decision
+	Total      int
+	Page       int
+	PerPage    int
+	TotalPages int
+}
 
 var activeDecisionCount prometheus.Gauge = promauto.NewGauge(prometheus.GaugeOpts{
 	Name: "active_decision_count",
@@ -99,6 +109,70 @@ func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values) []*models.Deci
 	}
 
 	return ret
+}
+
+// GetActiveDecisionsPaginated returns paginated decisions with metadata.
+// Query params: page (default 1), per_page (default 0 = all)
+func (dr *DecisionRegistry) GetActiveDecisionsPaginated(filter url.Values) PaginatedResult {
+	// Get all filtered and sorted decisions first
+	allDecisions := dr.GetActiveDecisions(filter)
+	total := len(allDecisions)
+
+	// Parse pagination params
+	page := 1
+	perPage := 0 // 0 means no pagination (return all)
+
+	if filter.Has("page") {
+		if p, err := strconv.Atoi(filter.Get("page")); err == nil && p > 0 {
+			page = p
+		}
+	}
+
+	if filter.Has("per_page") {
+		if pp, err := strconv.Atoi(filter.Get("per_page")); err == nil && pp > 0 {
+			perPage = pp
+		}
+	}
+
+	// If no pagination requested, return all results
+	if perPage == 0 {
+		return PaginatedResult{
+			Decisions:  allDecisions,
+			Total:      total,
+			Page:       1,
+			PerPage:    total,
+			TotalPages: 1,
+		}
+	}
+
+	// Calculate pagination
+	totalPages := (total + perPage - 1) / perPage // ceiling division
+	if totalPages == 0 {
+		totalPages = 1
+	}
+
+	// Clamp page to valid range
+	if page > totalPages {
+		page = totalPages
+	}
+
+	// Calculate slice bounds
+	start := (page - 1) * perPage
+	end := start + perPage
+	if end > total {
+		end = total
+	}
+	if start > total {
+		start = total
+	}
+
+	return PaginatedResult{
+		Decisions:  allDecisions[start:end],
+		Total:      total,
+		Page:       page,
+		PerPage:    perPage,
+		TotalPages: totalPages,
+	}
 }
 
 func (dr *DecisionRegistry) DeleteDecisions(decisions []*models.Decision) {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,227 @@
+package registry
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func createTestDecisions(count int) []*models.Decision {
+	decisions := make([]*models.Decision, count)
+	for i := range count {
+		val := "192.168.1." + string(rune('0'+i%10)) + string(rune('0'+i/10%10))
+		decisions[i] = &models.Decision{
+			Value:  strPtr(val),
+			Type:   strPtr("ban"),
+			Origin: strPtr("test"),
+		}
+	}
+	return decisions
+}
+
+func TestGetActiveDecisionsPaginated_NoParams(t *testing.T) {
+	dr := &DecisionRegistry{
+		ActiveDecisionsByValue: make(map[string]*models.Decision),
+	}
+
+	// Add 25 test decisions
+	decisions := createTestDecisions(25)
+	dr.AddDecisions(decisions)
+
+	// Without pagination params, should return all
+	result := dr.GetActiveDecisionsPaginated(url.Values{})
+
+	if result.Total != 25 {
+		t.Errorf("expected total 25, got %d", result.Total)
+	}
+	if len(result.Decisions) != 25 {
+		t.Errorf("expected 25 decisions, got %d", len(result.Decisions))
+	}
+	if result.Page != 1 {
+		t.Errorf("expected page 1, got %d", result.Page)
+	}
+	if result.TotalPages != 1 {
+		t.Errorf("expected 1 total page, got %d", result.TotalPages)
+	}
+}
+
+func TestGetActiveDecisionsPaginated_WithPagination(t *testing.T) {
+	dr := &DecisionRegistry{
+		ActiveDecisionsByValue: make(map[string]*models.Decision),
+	}
+
+	// Add 25 test decisions
+	decisions := createTestDecisions(25)
+	dr.AddDecisions(decisions)
+
+	// Request page 1 with 10 per page
+	params := url.Values{}
+	params.Set("page", "1")
+	params.Set("per_page", "10")
+
+	result := dr.GetActiveDecisionsPaginated(params)
+
+	if result.Total != 25 {
+		t.Errorf("expected total 25, got %d", result.Total)
+	}
+	if len(result.Decisions) != 10 {
+		t.Errorf("expected 10 decisions, got %d", len(result.Decisions))
+	}
+	if result.Page != 1 {
+		t.Errorf("expected page 1, got %d", result.Page)
+	}
+	if result.PerPage != 10 {
+		t.Errorf("expected per_page 10, got %d", result.PerPage)
+	}
+	if result.TotalPages != 3 {
+		t.Errorf("expected 3 total pages, got %d", result.TotalPages)
+	}
+}
+
+func TestGetActiveDecisionsPaginated_LastPage(t *testing.T) {
+	dr := &DecisionRegistry{
+		ActiveDecisionsByValue: make(map[string]*models.Decision),
+	}
+
+	// Add 25 test decisions
+	decisions := createTestDecisions(25)
+	dr.AddDecisions(decisions)
+
+	// Request page 3 (last page) with 10 per page
+	params := url.Values{}
+	params.Set("page", "3")
+	params.Set("per_page", "10")
+
+	result := dr.GetActiveDecisionsPaginated(params)
+
+	if result.Total != 25 {
+		t.Errorf("expected total 25, got %d", result.Total)
+	}
+	if len(result.Decisions) != 5 {
+		t.Errorf("expected 5 decisions on last page, got %d", len(result.Decisions))
+	}
+	if result.Page != 3 {
+		t.Errorf("expected page 3, got %d", result.Page)
+	}
+}
+
+func TestGetActiveDecisionsPaginated_PageOutOfRange(t *testing.T) {
+	dr := &DecisionRegistry{
+		ActiveDecisionsByValue: make(map[string]*models.Decision),
+	}
+
+	// Add 25 test decisions
+	decisions := createTestDecisions(25)
+	dr.AddDecisions(decisions)
+
+	// Request page 10 (beyond range) with 10 per page
+	params := url.Values{}
+	params.Set("page", "10")
+	params.Set("per_page", "10")
+
+	result := dr.GetActiveDecisionsPaginated(params)
+
+	// Should clamp to last page
+	if result.Page != 3 {
+		t.Errorf("expected page to be clamped to 3, got %d", result.Page)
+	}
+	if len(result.Decisions) != 5 {
+		t.Errorf("expected 5 decisions on last page, got %d", len(result.Decisions))
+	}
+}
+
+func TestGetActiveDecisionsPaginated_SortingConsistency(t *testing.T) {
+	dr := &DecisionRegistry{
+		ActiveDecisionsByValue: make(map[string]*models.Decision),
+	}
+
+	// Add decisions in random order
+	decisions := []*models.Decision{
+		{Value: strPtr("192.168.1.30"), Type: strPtr("ban"), Origin: strPtr("test")},
+		{Value: strPtr("192.168.1.10"), Type: strPtr("ban"), Origin: strPtr("test")},
+		{Value: strPtr("192.168.1.20"), Type: strPtr("ban"), Origin: strPtr("test")},
+		{Value: strPtr("192.168.1.40"), Type: strPtr("ban"), Origin: strPtr("test")},
+		{Value: strPtr("192.168.1.50"), Type: strPtr("ban"), Origin: strPtr("test")},
+	}
+	dr.AddDecisions(decisions)
+
+	// Get page 1 with 2 per page
+	params := url.Values{}
+	params.Set("page", "1")
+	params.Set("per_page", "2")
+
+	result1 := dr.GetActiveDecisionsPaginated(params)
+
+	// Results should be sorted - first 2 should be .10 and .20
+	if *result1.Decisions[0].Value != "192.168.1.10" {
+		t.Errorf("expected first decision to be 192.168.1.10, got %s", *result1.Decisions[0].Value)
+	}
+	if *result1.Decisions[1].Value != "192.168.1.20" {
+		t.Errorf("expected second decision to be 192.168.1.20, got %s", *result1.Decisions[1].Value)
+	}
+
+	// Get page 2 - should continue sorted order
+	params.Set("page", "2")
+	result2 := dr.GetActiveDecisionsPaginated(params)
+
+	if *result2.Decisions[0].Value != "192.168.1.30" {
+		t.Errorf("expected first decision on page 2 to be 192.168.1.30, got %s", *result2.Decisions[0].Value)
+	}
+}
+
+func TestGetActiveDecisionsPaginated_EmptyRegistry(t *testing.T) {
+	dr := &DecisionRegistry{
+		ActiveDecisionsByValue: make(map[string]*models.Decision),
+	}
+
+	params := url.Values{}
+	params.Set("page", "1")
+	params.Set("per_page", "10")
+
+	result := dr.GetActiveDecisionsPaginated(params)
+
+	if result.Total != 0 {
+		t.Errorf("expected total 0, got %d", result.Total)
+	}
+	if len(result.Decisions) != 0 {
+		t.Errorf("expected 0 decisions, got %d", len(result.Decisions))
+	}
+	if result.TotalPages != 1 {
+		t.Errorf("expected 1 total page (minimum), got %d", result.TotalPages)
+	}
+}
+
+func TestGetActiveDecisionsPaginated_InvalidParams(t *testing.T) {
+	dr := &DecisionRegistry{
+		ActiveDecisionsByValue: make(map[string]*models.Decision),
+	}
+
+	decisions := createTestDecisions(10)
+	dr.AddDecisions(decisions)
+
+	// Invalid page (negative/zero should default to 1)
+	params := url.Values{}
+	params.Set("page", "-1")
+	params.Set("per_page", "5")
+
+	result := dr.GetActiveDecisionsPaginated(params)
+
+	if result.Page != 1 {
+		t.Errorf("expected page to default to 1 for invalid input, got %d", result.Page)
+	}
+
+	// Invalid per_page (negative should mean no pagination)
+	params.Set("page", "1")
+	params.Set("per_page", "-5")
+
+	result = dr.GetActiveDecisionsPaginated(params)
+
+	if len(result.Decisions) != 10 {
+		t.Errorf("expected all 10 decisions for invalid per_page, got %d", len(result.Decisions))
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -162,15 +164,63 @@ func metricsMiddleware(blockListCfg *cfg.BlockListConfig, next http.HandlerFunc)
 
 func decisionMiddleware(next http.HandlerFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		decisions := registry.GlobalDecisionRegistry.GetActiveDecisions(r.URL.Query())
-		if len(decisions) == 0 {
+		result := registry.GlobalDecisionRegistry.GetActiveDecisionsPaginated(r.URL.Query())
+		if len(result.Decisions) == 0 && result.Total == 0 {
 			http.Error(w, "no decisions available", http.StatusNotFound)
 			return
 		}
 
-		ctx := context.WithValue(r.Context(), registry.GlobalDecisionRegistry.Key, decisions)
+		// Add pagination headers
+		w.Header().Set("X-Total-Count", strconv.Itoa(result.Total))
+		w.Header().Set("X-Page", strconv.Itoa(result.Page))
+		w.Header().Set("X-Per-Page", strconv.Itoa(result.PerPage))
+		w.Header().Set("X-Total-Pages", strconv.Itoa(result.TotalPages))
+
+		// Add Link headers for navigation
+		if linkHeader := buildLinkHeader(r.URL, result); linkHeader != "" {
+			w.Header().Set("Link", linkHeader)
+		}
+
+		ctx := context.WithValue(r.Context(), registry.GlobalDecisionRegistry.Key, result.Decisions)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	}
+}
+
+// buildLinkHeader creates RFC 5988 Link headers for pagination navigation
+func buildLinkHeader(reqURL *url.URL, result registry.PaginatedResult) string {
+	// No pagination headers needed if not paginated or only one page
+	if result.PerPage == 0 || result.TotalPages <= 1 {
+		return ""
+	}
+
+	var links []string
+	baseURL := *reqURL
+
+	// Helper to build a link for a specific page
+	buildLink := func(page int, rel string) string {
+		q := baseURL.Query()
+		q.Set("page", strconv.Itoa(page))
+		baseURL.RawQuery = q.Encode()
+		return fmt.Sprintf("<%s>; rel=%q", baseURL.String(), rel)
+	}
+
+	// First page
+	links = append(links, buildLink(1, "first"))
+
+	// Last page
+	links = append(links, buildLink(result.TotalPages, "last"))
+
+	// Previous page (if not on first page)
+	if result.Page > 1 {
+		links = append(links, buildLink(result.Page-1, "prev"))
+	}
+
+	// Next page (if not on last page)
+	if result.Page < result.TotalPages {
+		links = append(links, buildLink(result.Page+1, "next"))
+	}
+
+	return strings.Join(links, ", ")
 }
 
 func authMiddleware(blockListCfg *cfg.BlockListConfig, next http.HandlerFunc) func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/crowdsecurity/cs-blocklist-mirror/pkg/registry"
+)
+
+func TestBuildLinkHeader_NoPagination(t *testing.T) {
+	reqURL, _ := url.Parse("http://example.com/blocklist")
+
+	// No pagination (per_page = 0)
+	result := registry.PaginatedResult{
+		Page:       1,
+		PerPage:    0,
+		TotalPages: 1,
+	}
+
+	link := buildLinkHeader(reqURL, result)
+	if link != "" {
+		t.Errorf("expected empty link header for no pagination, got: %s", link)
+	}
+}
+
+func TestBuildLinkHeader_SinglePage(t *testing.T) {
+	reqURL, _ := url.Parse("http://example.com/blocklist?per_page=100")
+
+	result := registry.PaginatedResult{
+		Page:       1,
+		PerPage:    100,
+		TotalPages: 1,
+	}
+
+	link := buildLinkHeader(reqURL, result)
+	if link != "" {
+		t.Errorf("expected empty link header for single page, got: %s", link)
+	}
+}
+
+func TestBuildLinkHeader_FirstPage(t *testing.T) {
+	reqURL, _ := url.Parse("http://example.com/blocklist?per_page=10")
+
+	result := registry.PaginatedResult{
+		Page:       1,
+		PerPage:    10,
+		TotalPages: 5,
+	}
+
+	link := buildLinkHeader(reqURL, result)
+
+	// Should have first, last, and next (no prev on first page)
+	if !strings.Contains(link, `rel="first"`) {
+		t.Error("expected first link")
+	}
+	if !strings.Contains(link, `rel="last"`) {
+		t.Error("expected last link")
+	}
+	if !strings.Contains(link, `rel="next"`) {
+		t.Error("expected next link")
+	}
+	if strings.Contains(link, `rel="prev"`) {
+		t.Error("should not have prev link on first page")
+	}
+	if !strings.Contains(link, "page=2") {
+		t.Error("next link should point to page 2")
+	}
+	if !strings.Contains(link, "page=5") {
+		t.Error("last link should point to page 5")
+	}
+}
+
+func TestBuildLinkHeader_MiddlePage(t *testing.T) {
+	reqURL, _ := url.Parse("http://example.com/blocklist?per_page=10&page=3")
+
+	result := registry.PaginatedResult{
+		Page:       3,
+		PerPage:    10,
+		TotalPages: 5,
+	}
+
+	link := buildLinkHeader(reqURL, result)
+
+	// Should have all four links
+	if !strings.Contains(link, `rel="first"`) {
+		t.Error("expected first link")
+	}
+	if !strings.Contains(link, `rel="last"`) {
+		t.Error("expected last link")
+	}
+	if !strings.Contains(link, `rel="prev"`) {
+		t.Error("expected prev link")
+	}
+	if !strings.Contains(link, `rel="next"`) {
+		t.Error("expected next link")
+	}
+}
+
+func TestBuildLinkHeader_LastPage(t *testing.T) {
+	reqURL, _ := url.Parse("http://example.com/blocklist?per_page=10&page=5")
+
+	result := registry.PaginatedResult{
+		Page:       5,
+		PerPage:    10,
+		TotalPages: 5,
+	}
+
+	link := buildLinkHeader(reqURL, result)
+
+	// Should have first, last, and prev (no next on last page)
+	if !strings.Contains(link, `rel="first"`) {
+		t.Error("expected first link")
+	}
+	if !strings.Contains(link, `rel="last"`) {
+		t.Error("expected last link")
+	}
+	if !strings.Contains(link, `rel="prev"`) {
+		t.Error("expected prev link")
+	}
+	if strings.Contains(link, `rel="next"`) {
+		t.Error("should not have next link on last page")
+	}
+	if !strings.Contains(link, "page=4") {
+		t.Error("prev link should point to page 4")
+	}
+}
+
+func TestBuildLinkHeader_PreservesOtherParams(t *testing.T) {
+	reqURL, _ := url.Parse("http://example.com/blocklist?per_page=10&ipv4only=1&origin=crowdsec")
+
+	result := registry.PaginatedResult{
+		Page:       1,
+		PerPage:    10,
+		TotalPages: 3,
+	}
+
+	link := buildLinkHeader(reqURL, result)
+
+	// Should preserve other query params
+	if !strings.Contains(link, "ipv4only=1") {
+		t.Error("expected ipv4only param to be preserved")
+	}
+	if !strings.Contains(link, "origin=crowdsec") {
+		t.Error("expected origin param to be preserved")
+	}
+}


### PR DESCRIPTION
Add pagination query parameters (page, per_page) to blocklist endpoints. Results are sorted before pagination to ensure consistent ordering across requests despite Go's unordered map iteration.

Response headers include:
- X-Total-Count, X-Page, X-Per-Page, X-Total-Pages
- RFC 5988 Link headers for navigation (first, last, prev, next)

Backwards compatible: without per_page param, returns all results.